### PR TITLE
Adding serialization capability. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ path = "src/lib.rs"
 [[example]]
 name = "basic"
 
+[[example]]
+name = "serialization"
+
 [[bench]]
 name = "example"
 harness = false

--- a/examples/rerandomize.rs
+++ b/examples/rerandomize.rs
@@ -2,7 +2,6 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-// use cupcake::integer_arith::scalar::Scalar;
 use cupcake::traits::{AdditiveHomomorphicScheme, PKEncryption, SKEncryption};
 
 fn smartprint<T: std::fmt::Debug>(v: &Vec<T>) {

--- a/examples/serialization.rs
+++ b/examples/serialization.rs
@@ -3,7 +3,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 use cupcake::traits::*;
-use cupcake::FVCiphertext;
 fn smartprint<T: std::fmt::Debug>(v: &Vec<T>) {
     println!("[{:?}, {:?}, ..., {:?}]", v[0], v[1], v[v.len() - 1]);
 }
@@ -29,14 +28,11 @@ fn main() {
     let serialized_ctw = ctw.to_bytes();
 
     // deserializing
-    let mut deserialized_ctv = FVCiphertext::from_bytes(&serialized_ctv);
-    let mut deserialized_ctw = FVCiphertext::from_bytes(&serialized_ctw);
+    let mut deserialized_ctv = fv.from_bytes(&serialized_ctv);
+    let deserialized_ctw = fv.from_bytes(&serialized_ctw);
 
     // add ctw into ctv
     println!("Adding the deserialized ciphertexts...");
-    fv.set_context(&mut deserialized_ctv);
-    fv.set_context(&mut deserialized_ctw);
-
     fv.add_inplace(&mut deserialized_ctv, &deserialized_ctw);
     println!("Decrypting the sum...");
     let pt_actual = fv.decrypt(&deserialized_ctv, &sk);

--- a/examples/serialization.rs
+++ b/examples/serialization.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+use cupcake::traits::*;
+use cupcake::FVCiphertext;
+fn smartprint<T: std::fmt::Debug>(v: &Vec<T>) {
+    println!("[{:?}, {:?}, ..., {:?}]", v[0], v[1], v[v.len() - 1]);
+}
+
+fn main() {
+    let fv = cupcake::default();
+
+    let (pk, sk) = fv.generate_keypair();
+
+    print!("Encrypting a constant vector v of 1s...");
+    let v = vec![1; fv.n];
+
+    let ctv = fv.encrypt(&v, &pk);
+
+    print!("Encrypting a constant vector w of 2s...");
+    let w = vec![2; fv.n];
+    let ctw = fv.encrypt(&w, &pk);
+
+    // serialize
+    print!("Serializing the ciphertexts...");
+
+    let serialized_ctv = ctv.to_bytes();
+    let serialized_ctw = ctw.to_bytes();
+
+    // deserializing
+    let mut deserialized_ctv = FVCiphertext::from_bytes(&serialized_ctv);
+    let deserialized_ctw = FVCiphertext::from_bytes(&serialized_ctw);
+
+    // add ctw into ctv
+    print!("Adding the deserialized ciphertexts...");
+    fv.add_inplace(&mut deserialized_ctv, &deserialized_ctw);
+    print!("Decrypting the sum...");
+    let pt_actual = fv.decrypt(&deserialized_ctv, &sk);
+    print!("decrypted v+w: ");
+    smartprint(&pt_actual);
+}

--- a/examples/serialization.rs
+++ b/examples/serialization.rs
@@ -13,17 +13,17 @@ fn main() {
 
     let (pk, sk) = fv.generate_keypair();
 
-    print!("Encrypting a constant vector v of 1s...");
+    println!("Encrypting a constant vector v of 1s...");
     let v = vec![1; fv.n];
 
     let ctv = fv.encrypt(&v, &pk);
 
-    print!("Encrypting a constant vector w of 2s...");
+    println!("Encrypting a constant vector w of 2s...");
     let w = vec![2; fv.n];
     let ctw = fv.encrypt(&w, &pk);
 
     // serialize
-    print!("Serializing the ciphertexts...");
+    println!("Serializing the ciphertexts...");
 
     let serialized_ctv = ctv.to_bytes();
     let serialized_ctw = ctw.to_bytes();
@@ -33,13 +33,13 @@ fn main() {
     let mut deserialized_ctw = FVCiphertext::from_bytes(&serialized_ctw);
 
     // add ctw into ctv
-    print!("Adding the deserialized ciphertexts...");
+    println!("Adding the deserialized ciphertexts...");
     fv.set_context(&mut deserialized_ctv);
     fv.set_context(&mut deserialized_ctw);
 
     fv.add_inplace(&mut deserialized_ctv, &deserialized_ctw);
-    print!("Decrypting the sum...");
+    println!("Decrypting the sum...");
     let pt_actual = fv.decrypt(&deserialized_ctv, &sk);
-    print!("decrypted v+w: ");
+    println!("decrypted v+w: ");
     smartprint(&pt_actual);
 }

--- a/examples/serialization.rs
+++ b/examples/serialization.rs
@@ -30,10 +30,13 @@ fn main() {
 
     // deserializing
     let mut deserialized_ctv = FVCiphertext::from_bytes(&serialized_ctv);
-    let deserialized_ctw = FVCiphertext::from_bytes(&serialized_ctw);
+    let mut deserialized_ctw = FVCiphertext::from_bytes(&serialized_ctw);
 
     // add ctw into ctv
     print!("Adding the deserialized ciphertexts...");
+    fv.set_context(&mut deserialized_ctv);
+    fv.set_context(&mut deserialized_ctw);
+
     fv.add_inplace(&mut deserialized_ctv, &deserialized_ctw);
     print!("Decrypting the sum...");
     let pt_actual = fv.decrypt(&deserialized_ctv, &sk);

--- a/src/integer_arith/scalar.rs
+++ b/src/integer_arith/scalar.rs
@@ -65,6 +65,10 @@ impl Scalar {
             bit_count: 64 - q.leading_zeros() as usize,
         }
     }
+
+    pub fn rep(&self) -> u64{
+        self.rep
+    }
 }
 
 impl PartialEq for Scalar {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,39 @@
 //! let actual = scheme.decrypt(&ct, &sk);
 //! let expected = mu;
 //! assert_eq!(actual, expected);
+//! ```
+//! # Serialization
+//! We provide methods to serialize  a ciphertext into a ```Vec<u8>```. Note that after deserialization, a proper context needs to be set before the further operations can be done on the ciphertext. See
+//! the following example:
+//! ```
+//! # let scheme = cupcake::default();
+//! # use cupcake::traits::{SKEncryption, PKEncryption};
+//! # let (pk, sk) = scheme.generate_keypair();
+//! # use cupcake::traits::{AdditiveHomomorphicScheme};
+//! use crate::cupcake::traits::Serializable;
+//! let v = vec![1; scheme.n];
+//! let w = vec![1; scheme.n];
+//! let ctv = scheme.encrypt(&v, &pk);
+//! let ctw = scheme.encrypt(&w, &pk);
+//! ```
+//! We can call the `to_bytes` function to serialize.
+//! ```
+//! let ctv_serialized = ctv.to_bytes();
+//! let ctw_serialized = ctw.to_bytes();
+//! ```
+//! In order to deserialize, use `scheme.from_bytes`.
+//! ```
+//! let mut ctv_deserialized = scheme.from_bytes(&ctv_serialized);
+//! let ctw_deserialized = scheme.from_bytes(&ctw_serialized);
+//! assert_eq!(ctv, ctv_deserialized);
+//! ```
+//! We can perform homomorphic operations on deserialized ciphertexts.
+//! ```
+//! ctv_deserialized.add_inplace(& ctw_deserialized);
+//! let expected = vec![2; scheme.n];
+//! let actual = scheme.decrypt(&ctv_deserialized, &sk);
+//! assert_eq!(actual, expected);
+//! ```
 
 
 pub(crate) mod integer_arith;
@@ -169,7 +202,7 @@ where
 // constructor and random poly sampling
 impl<T> FV<T>
 where
-    T: ArithUtils<T> + Clone + PartialEq,
+    T: ArithUtils<T> + Clone + PartialEq + Serializable,
     RqPoly<T>: FiniteRingElt + NTT<T>,
 {
     pub fn new(n: usize, q: &T) -> Self {
@@ -195,7 +228,13 @@ where
         }
     }
 
-    pub fn set_context(&self, ctxt: &mut FVCiphertext<T>){
+    pub fn from_bytes(&self, bytes: &Vec<u8>) -> FVCiphertext<T>{
+        let mut ct = FVCiphertext::<T>::from_bytes(bytes);
+        self.set_context(&mut ct);
+        ct
+    }
+
+    fn set_context(&self, ctxt: &mut FVCiphertext<T>){
         ctxt.0.set_context(self.context.clone());
         ctxt.1.set_context(self.context.clone());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,11 @@ where
             poly_multiplier: default_multiplier,
         }
     }
+
+    pub fn set_context(&self, ctxt: &mut FVCiphertext<T>){
+        ctxt.0.set_context(self.context.clone());
+        ctxt.1.set_context(self.context.clone());
+    }
 }
 
 impl FV<Scalar> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ impl FV<Scalar> {
             qdivtwo: Scalar::div(&q, &Scalar::from_u32_raw(2)), // &q/2,
             stdev: 3.2,
             flooding_stdev: 2f64.powi(40),
-            context: context,
+            context,
             poly_multiplier: default_multiplier,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,18 +106,49 @@
 //! ```
 //! We can call the `to_bytes` function to serialize.
 //! ```
+//! # let scheme = cupcake::default();
+//! # use cupcake::traits::{SKEncryption, PKEncryption};
+//! # let (pk, sk) = scheme.generate_keypair();
+//! # use cupcake::traits::{AdditiveHomomorphicScheme};
+//! # use crate::cupcake::traits::Serializable;
+//! # let v = vec![1; scheme.n];
+//! # let w = vec![1; scheme.n];
+//! # let ctv = scheme.encrypt(&v, &pk);
+//! # let ctw = scheme.encrypt(&w, &pk);
 //! let ctv_serialized = ctv.to_bytes();
 //! let ctw_serialized = ctw.to_bytes();
 //! ```
 //! In order to deserialize, use `scheme.from_bytes`.
 //! ```
+//! # let scheme = cupcake::default();
+//! # use cupcake::traits::{SKEncryption, PKEncryption};
+//! # let (pk, sk) = scheme.generate_keypair();
+//! # use cupcake::traits::{AdditiveHomomorphicScheme};
+//! # use crate::cupcake::traits::Serializable;
+//! # let v = vec![1; scheme.n];
+//! # let w = vec![1; scheme.n];
+//! # let ctv = scheme.encrypt(&v, &pk);
+//! # let ctw = scheme.encrypt(&w, &pk);
+//! # let ctv_serialized = ctv.to_bytes();
+//! # let ctw_serialized = ctw.to_bytes();
 //! let mut ctv_deserialized = scheme.from_bytes(&ctv_serialized);
 //! let ctw_deserialized = scheme.from_bytes(&ctw_serialized);
 //! assert_eq!(ctv, ctv_deserialized);
 //! ```
 //! We can perform homomorphic operations on deserialized ciphertexts.
 //! ```
-//! ctv_deserialized.add_inplace(& ctw_deserialized);
+//! # let scheme = cupcake::default();
+//! # let (pk, sk) = scheme.generate_keypair();
+//! # use crate::cupcake::traits::*;
+//! # let v = vec![1; scheme.n];
+//! # let w = vec![1; scheme.n];
+//! # let ctv = scheme.encrypt(&v, &pk);
+//! # let ctw = scheme.encrypt(&w, &pk);
+//! # let ctv_serialized = ctv.to_bytes();
+//! # let ctw_serialized = ctw.to_bytes();
+//! # let mut ctv_deserialized = scheme.from_bytes(&ctv_serialized);
+//! # let ctw_deserialized = scheme.from_bytes(&ctw_serialized);
+//! scheme.add_inplace(&mut ctv_deserialized, &ctw_deserialized);
 //! let expected = vec![2; scheme.n];
 //! let actual = scheme.decrypt(&ctv_deserialized, &sk);
 //! assert_eq!(actual, expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@
 pub(crate) mod integer_arith;
 mod rqpoly;
 pub mod traits;
+mod serialize;
 mod utils;
 
 use integer_arith::scalar::Scalar;

--- a/src/rqpoly.rs
+++ b/src/rqpoly.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// Holds the context information for RqPolys, including degree n, modulus q, and optionally precomputed
 /// roots of unity for NTT purposes.
 #[derive(Debug)]
-pub(crate) struct RqPolyContext<T> {
+pub struct RqPolyContext<T> {
     pub n: usize,
     pub q: T,
     pub is_ntt_enabled: bool,
@@ -32,6 +32,10 @@ impl<T> RqPoly<T> where T:Clone{
             coeffs: coeffs.to_vec(),
             is_ntt_form,
         }
+    }
+
+    pub fn set_context(&mut self, context: Arc<RqPolyContext<T>>){
+        self.context = Some(context);
     }
 }
 

--- a/src/rqpoly.rs
+++ b/src/rqpoly.rs
@@ -30,7 +30,7 @@ impl<T> RqPoly<T> where T:Clone{
         RqPoly{
             context: None,
             coeffs: coeffs.to_vec(),
-            is_ntt_form: is_ntt_form,
+            is_ntt_form,
         }
     }
 }
@@ -44,7 +44,7 @@ impl<T> PartialEq for RqPoly<T> where T: PartialEq {
             if self.coeffs[i] != other.coeffs[i] { return false; }
         }
         if self.is_ntt_form != other.is_ntt_form { return false; }
-        return true
+         true
     }
 }
 
@@ -80,7 +80,7 @@ where
 {
     pub fn new(n: usize, q: &T) -> Self {
         let mut a = RqPolyContext {
-            n: n,
+            n,
             q: q.clone(),
             is_ntt_enabled: false,
             invroots: vec![],

--- a/src/rqpoly.rs
+++ b/src/rqpoly.rs
@@ -162,7 +162,6 @@ where
 
     fn forward_transform(&mut self) {
         let context = self.context.as_ref().unwrap();
-
         if self.is_ntt_form {
             panic!("is already in ntt");
         }
@@ -191,7 +190,6 @@ where
 
     fn inverse_transform(&mut self) {
         let context = self.context.as_ref().unwrap();
-
         if !self.is_ntt_form {
             panic!("is already not in ntt");
         }
@@ -228,7 +226,6 @@ where
 
     fn coeffwise_multiply(&self, other: &Self) -> Self {
         let context = self.context.as_ref().unwrap();
-
         let mut c = self.clone();
         for (inputs, cc) in self
             .coeffs

--- a/src/rqpoly.rs
+++ b/src/rqpoly.rs
@@ -25,11 +25,11 @@ pub struct RqPoly<T> {
     pub is_ntt_form: bool,
 }
 
-impl<T> RqPoly<T>{
-    pub fn new(coeffs: Vec<T>, is_ntt_form:bool) -> Self{
+impl<T> RqPoly<T> where T:Clone{
+    pub fn new(coeffs: &Vec<T>, is_ntt_form:bool) -> Self{
         RqPoly{
             context: None,
-            coeffs: coeffs,
+            coeffs: coeffs.to_vec(),
             is_ntt_form: is_ntt_form,
         }
     }

--- a/src/rqpoly.rs
+++ b/src/rqpoly.rs
@@ -20,9 +20,32 @@ pub(crate) struct RqPolyContext<T> {
 /// Polynomials in Rq = Zq[x]/(x^n + 1).
 #[derive(Clone, Debug)]
 pub struct RqPoly<T> {
-    context: Arc<RqPolyContext<T>>,
+    context: Option<Arc<RqPolyContext<T>>>,
     pub coeffs: Vec<T>,
     pub is_ntt_form: bool,
+}
+
+impl<T> RqPoly<T>{
+    pub fn new(coeffs: Vec<T>, is_ntt_form:bool) -> Self{
+        RqPoly{
+            context: None,
+            coeffs: coeffs,
+            is_ntt_form: is_ntt_form,
+        }
+    }
+}
+
+impl<T> PartialEq for RqPoly<T> where T: PartialEq {
+    fn eq(&self, other: &Self) -> bool {
+        if self.coeffs.len() != other.coeffs.len() {
+            return false
+        }
+        for i in 0..self.coeffs.len(){
+            if self.coeffs[i] != other.coeffs[i] { return false; }
+        }
+        if self.is_ntt_form != other.is_ntt_form { return false; }
+        return true
+    }
 }
 
 /// Number-theoretic transform (NTT) and fast polynomial multiplication based on NTT.
@@ -134,12 +157,14 @@ where
     }
 
     fn forward_transform(&mut self) {
+        let context = self.context.as_ref().unwrap();
+
         if self.is_ntt_form {
             panic!("is already in ntt");
         }
 
-        let n = self.context.n;
-        let q = self.context.q.clone();
+        let n = context.n;
+        let q = context.q.clone();
 
         let mut t = n;
         let mut m = 1;
@@ -148,7 +173,7 @@ where
             for i in 0..m {
                 let j1 = 2 * i * t;
                 let j2 = j1 + t - 1;
-                let phi = &self.context.roots[m + i];
+                let phi = &context.roots[m + i];
                 for j in j1..j2 + 1 {
                     let x = T::mul_mod(&self.coeffs[j + t], &phi, &q);
                     self.coeffs[j + t] = T::sub_mod(&self.coeffs[j], &x, &q);
@@ -161,11 +186,13 @@ where
     }
 
     fn inverse_transform(&mut self) {
+        let context = self.context.as_ref().unwrap();
+
         if !self.is_ntt_form {
             panic!("is already not in ntt");
         }
-        let n = self.context.n;
-        let q = self.context.q.clone();
+        let n = context.n;
+        let q = context.q.clone();
 
         let mut t = 1;
         let mut m = n;
@@ -175,7 +202,7 @@ where
             let h = m >> 1;
             for i in 0..h {
                 let j2 = j1 + t - 1;
-                let s = &self.context.invroots[h + i];
+                let s = &context.invroots[h + i];
                 for j in j1..j2 + 1 {
                     let u = self.coeffs[j].clone();
                     let v = self.coeffs[j + t].clone();
@@ -196,6 +223,8 @@ where
     }
 
     fn coeffwise_multiply(&self, other: &Self) -> Self {
+        let context = self.context.as_ref().unwrap();
+
         let mut c = self.clone();
         for (inputs, cc) in self
             .coeffs
@@ -203,7 +232,7 @@ where
             .zip(other.coeffs.iter())
             .zip(c.coeffs.iter_mut())
         {
-            *cc = T::mul_mod(inputs.0, inputs.1, &self.context.q);
+            *cc = T::mul_mod(inputs.0, inputs.1, &context.q);
         }
         c
     }
@@ -229,31 +258,36 @@ where
     T: ArithUtils<T> + Clone,
 {
     fn add_inplace(&mut self, other: &Self) {
+        let context = self.context.as_ref().unwrap();
         let iter = self.coeffs.iter_mut().zip(other.coeffs.iter());
         for (x, y) in iter {
-            *x = T::add_mod(x, y, &self.context.q);
+            *x = T::add_mod(x, y, &context.q);
         }
     }
 
     fn sub_inplace(&mut self, other: &Self) {
+        let context = self.context.as_ref().unwrap();
         let iter = self.coeffs.iter_mut().zip(other.coeffs.iter());
         for (x, y) in iter {
-            *x = T::sub_mod(x, y, &self.context.q);
+            *x = T::sub_mod(x, y, &context.q);
         }
     }
 
     fn negate_inplace(&mut self) {
+        let context = self.context.as_ref().unwrap();
         for x in self.coeffs.iter_mut() {
-            *x = T::sub_mod(&self.context.q, x, &self.context.q);
+            *x = T::sub_mod(&context.q, x, &context.q);
         }
     }
 
     // naive multiplication
     fn multiply(&self, other: &Self) -> Self {
+        // check context exists
+        let context = self.context.as_ref().unwrap();
         let f = &self.coeffs;
         let g = &other.coeffs;
-        let n = self.context.n;
-        let q = self.context.q.clone();
+        let n = context.n;
+        let q = context.q.clone();
         let mut res = vec![T::zero(); n];
 
         for i in 0..n {
@@ -261,7 +295,7 @@ where
                 let tmp = T::mul_mod(&f[j], &g[i - j], &q);
                 res[i] = T::add_mod(&res[i], &tmp, &q);
             }
-            for j in i + 1..self.context.n {
+            for j in i + 1..context.n {
                 let tmp = T::mul_mod(&f[j], &g[n + i - j], &q);
                 res[i] = T::sub_mod(&res[i], &tmp, &q);
             }
@@ -270,7 +304,7 @@ where
         RqPoly {
             coeffs: res,
             is_ntt_form: false,
-            context: self.context.clone(),
+            context: Some(context.clone()),
         }
     }
 }
@@ -300,7 +334,7 @@ pub(crate) mod randutils {
         RqPoly {
             coeffs: c,
             is_ntt_form: false,
-            context: context.clone(),
+            context: Some(context.clone()),
         }
     }
 
@@ -321,7 +355,7 @@ pub(crate) mod randutils {
         RqPoly {
             coeffs: c,
             is_ntt_form: false,
-            context: context,
+            context: Some(context),
         }
     }
 
@@ -347,7 +381,7 @@ pub(crate) mod randutils {
         RqPoly {
             coeffs: c,
             is_ntt_form: false,
-            context: context,
+            context: Some(context),
         }
     }
 
@@ -364,7 +398,7 @@ pub(crate) mod randutils {
         RqPoly {
             coeffs: c,
             is_ntt_form: false,
-            context: context.clone(),
+            context: Some(context.clone()),
         }
     }
 }
@@ -386,7 +420,7 @@ mod tests {
         RqPoly {
             coeffs: c,
             is_ntt_form: false,
-            context: context.clone(),
+            context: Some(context.clone()),
         }
     }
     #[test]

--- a/src/rqpoly.rs
+++ b/src/rqpoly.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// Holds the context information for RqPolys, including degree n, modulus q, and optionally precomputed
 /// roots of unity for NTT purposes.
 #[derive(Debug)]
-pub struct RqPolyContext<T> {
+pub(crate) struct RqPolyContext<T> {
     pub n: usize,
     pub q: T,
     pub is_ntt_enabled: bool,
@@ -34,7 +34,7 @@ impl<T> RqPoly<T> where T:Clone{
         }
     }
 
-    pub fn set_context(&mut self, context: Arc<RqPolyContext<T>>){
+    pub(crate) fn set_context(&mut self, context: Arc<RqPolyContext<T>>){
         self.context = Some(context);
     }
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,10 +1,15 @@
 // use serde::{Serialize, Deserialize};
 use crate::integer_arith::scalar::Scalar;
 use crate::rqpoly::RqPoly;
-use crate::{FV, FVCiphertext};
 use crate::Serializable;
-use crate::traits::*;
+use crate::FVCiphertext;
+
+#[cfg(test)]
+use crate::FV;
+#[cfg(test)]
 use crate::integer_arith::ArithUtils;
+#[cfg(test)]
+use crate::traits::*;
 
 use std::convert::From;
 use std::convert::TryInto;
@@ -98,13 +103,11 @@ mod tests {
     assert_eq!(testpoly, deserialized);
   }
 
-
-
   #[test]
   fn test_fvciphertext_serialization(){
     // test ciphertext serialization
     let fv = FV::<Scalar>::default_2048();
-    let (pk, sk) = fv.generate_keypair();
+    let (pk, _) = fv.generate_keypair();
     let mut v = vec![0; fv.n];
     for i in 0..fv.n {
         v[i] = i as u8;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,9 +1,11 @@
 // use serde::{Serialize, Deserialize};
 use crate::integer_arith::scalar::Scalar;
-use crate::integer_arith::ArithUtils;
 use crate::rqpoly::RqPoly;
-use crate::FVCiphertext;
+use crate::{FV, FVCiphertext};
 use crate::Serializable;
+use crate::traits::*;
+use crate::integer_arith::ArithUtils;
+
 use std::convert::From;
 use std::convert::TryInto;
 
@@ -32,7 +34,7 @@ impl Serializable for Scalar {
 
 impl<T> Serializable for RqPoly<T>
 where
-  T: Serializable,
+  T: Serializable + Clone,
 {
   fn to_bytes(&self) -> std::vec::Vec<u8> {
     let mut vec: Vec<u8> = Vec::new();
@@ -52,19 +54,24 @@ where
       coeffs.push(T::from_bytes(&bytes[i..i+8].to_vec()));
       i += 8;
     }
-    RqPoly::new(coeffs, is_ntt_form)
+    RqPoly::new(&coeffs, is_ntt_form)
   }
 }
 
 impl<T> Serializable for FVCiphertext<T>
 where
-  T: Serializable,
+  T: Serializable + Clone,
 {
   fn to_bytes(&self) -> std::vec::Vec<u8> {
-    todo!()
+    let mut ct0_bytes = self.0.to_bytes();
+    let mut ct1_bytes = self.1.to_bytes();
+    ct0_bytes.append(&mut ct1_bytes);
+    ct0_bytes
   }
-  fn from_bytes(_: &std::vec::Vec<u8>) -> Self {
-    todo!()
+  fn from_bytes(bytes: &std::vec::Vec<u8>) -> Self {
+    let twon = bytes.len();
+    let n = twon / 2;
+    (RqPoly::from_bytes(&bytes[0..n].to_vec()),RqPoly::from_bytes(&bytes[n..twon].to_vec()))
   }
 }
 
@@ -85,9 +92,46 @@ mod tests {
     for i in 0..4 {
       coeffs.push(Scalar::from_u64_raw(i));
     }
-    let testpoly = RqPoly::<Scalar>::new(coeffs, false);
+    let testpoly = RqPoly::<Scalar>::new(&coeffs, false);
     let bytes = testpoly.to_bytes();
     let deserialized = RqPoly::<Scalar>::from_bytes(&bytes);
     assert_eq!(testpoly, deserialized);
   }
+
+
+
+  #[test]
+  fn test_fvciphertext_serialization(){
+    // test ciphertext serialization
+    let fv = FV::<Scalar>::default_2048();
+    let (pk, sk) = fv.generate_keypair();
+    let mut v = vec![0; fv.n];
+    for i in 0..fv.n {
+        v[i] = i as u8;
+    }
+    // encrypt v
+    let ct = fv.encrypt(&v, &pk);
+    let bytes = ct.to_bytes();
+    let ct_deserialized = FVCiphertext::from_bytes(&bytes);
+    assert_eq!(ct_deserialized, ct);
+  }
+  // fn test_rqpoly_serialization_with_context() {
+  //   let context = RqPolyContext::new(4, &Scalar::new_modulus(12289));
+  //   let arc = Arc::new(context);
+  //   let mut coeffs = Vec::<Scalar>::new();
+  //   for i in 0..4 {
+  //     coeffs.push(Scalar::from_u64_raw(i));
+  //   }
+
+  //   let testpoly = RqPoly::<Scalar>::new(coeffs, false);
+
+  //   let bytes = testpoly.to_bytes();
+  //   let deserialized = RqPoly::<Scalar>::from_bytes(&bytes);
+  //   deserialized.set_context(context);
+
+  //   // assert_eq!(testpoly, deserialized);
+  //   // Check that result is the same.
+
+  // }
+
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,4 +1,7 @@
-// use serde::{Serialize, Deserialize};
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 use crate::integer_arith::scalar::Scalar;
 use crate::rqpoly::RqPoly;
 use crate::Serializable;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,16 +1,13 @@
 // use serde::{Serialize, Deserialize};
+use crate::integer_arith::scalar::Scalar;
+use crate::integer_arith::ArithUtils;
+use crate::rqpoly::RqPoly;
+use crate::FVCiphertext;
 use crate::Serializable;
 use std::convert::From;
-use crate::integer_arith::scalar::Scalar;
-use crate::rqpoly::RqPoly;
 use std::convert::TryInto;
 
-pub struct RqPolyWireModel<T> {
-  pub coeffs: Vec<T>,
-  pub is_ntt_form: bool,
-}
-
-pub struct ScalarWireModel{
+pub struct ScalarWireModel {
   pub rep: u64,
 }
 
@@ -20,8 +17,7 @@ impl From<Scalar> for ScalarWireModel {
   }
 }
 
-
-impl Serializable for Scalar{
+impl Serializable for Scalar {
   fn to_bytes(&self) -> std::vec::Vec<u8> {
     let bytes = self.rep().to_be_bytes();
     let mut vec: Vec<u8> = vec![0; 8];
@@ -34,19 +30,40 @@ impl Serializable for Scalar{
   }
 }
 
-impl<T> Serializable for RqPoly<T> where T: Serializable{
+impl<T> Serializable for RqPoly<T>
+where
+  T: Serializable,
+{
   fn to_bytes(&self) -> std::vec::Vec<u8> {
-    let mut vec: Vec<u8> = vec![0,0];
+    let mut vec: Vec<u8> = Vec::new();
     // push in the is ntt form.
     vec.push(self.is_ntt_form as u8);
-    for i in 0..self.coeffs.len(){
+    for i in 0..self.coeffs.len() {
       let mut bytes = self.coeffs[i].to_bytes();
-      // append
-      vec.append(& mut bytes);
+      vec.append(&mut bytes);
     }
     vec
   }
   fn from_bytes(bytes: &std::vec::Vec<u8>) -> Self {
+    let mut coeffs = Vec::new();
+    let is_ntt_form  = bytes[0] != 0;
+    let mut  i : usize = 1;
+    while i + 8 <= bytes.len() {
+      coeffs.push(T::from_bytes(&bytes[i..i+8].to_vec()));
+      i += 8;
+    }
+    RqPoly::new(coeffs, is_ntt_form)
+  }
+}
+
+impl<T> Serializable for FVCiphertext<T>
+where
+  T: Serializable,
+{
+  fn to_bytes(&self) -> std::vec::Vec<u8> {
+    todo!()
+  }
+  fn from_bytes(_: &std::vec::Vec<u8>) -> Self {
     todo!()
   }
 }
@@ -62,23 +79,15 @@ mod tests {
     assert_eq!(c, deserialized_c);
   }
 
-  // fn test_rqpoly_serialization(){
-  //   let context = RqPolyContext::new(4, &Scalar::new_modulus(12289));
-  //   let arc = Arc::new(context);
-  //   let a = from_vec(&vec![1, 0, 0, 0], arc.clone());
-  //   // initialize RqPolys
-  //   // serialize
-  //   // check get back the same poly
-  // }
+  #[test]
+  fn test_rqpoly_serialization() {
+    let mut coeffs = Vec::<Scalar>::new();
+    for i in 0..4 {
+      coeffs.push(Scalar::from_u64_raw(i));
+    }
+    let testpoly = RqPoly::<Scalar>::new(coeffs, false);
+    let bytes = testpoly.to_bytes();
+    let deserialized = RqPoly::<Scalar>::from_bytes(&bytes);
+    assert_eq!(testpoly, deserialized);
+  }
 }
-
-
-
-// impl<T> Serializable for RqPolyWireModel<T> where T: Serialize{
-
-// }
-
-
-// impl Serializable for ScalarWireModel{
-
-// }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -14,18 +14,7 @@ use crate::integer_arith::ArithUtils;
 #[cfg(test)]
 use crate::traits::*;
 
-use std::convert::From;
 use std::convert::TryInto;
-
-pub struct ScalarWireModel {
-  pub rep: u64,
-}
-
-impl From<Scalar> for ScalarWireModel {
-  fn from(item: Scalar) -> Self {
-    ScalarWireModel { rep: item.rep() }
-  }
-}
 
 impl Serializable for Scalar {
   fn to_bytes(&self) -> std::vec::Vec<u8> {
@@ -121,23 +110,4 @@ mod tests {
     let ct_deserialized = FVCiphertext::from_bytes(&bytes);
     assert_eq!(ct_deserialized, ct);
   }
-  // fn test_rqpoly_serialization_with_context() {
-  //   let context = RqPolyContext::new(4, &Scalar::new_modulus(12289));
-  //   let arc = Arc::new(context);
-  //   let mut coeffs = Vec::<Scalar>::new();
-  //   for i in 0..4 {
-  //     coeffs.push(Scalar::from_u64_raw(i));
-  //   }
-
-  //   let testpoly = RqPoly::<Scalar>::new(coeffs, false);
-
-  //   let bytes = testpoly.to_bytes();
-  //   let deserialized = RqPoly::<Scalar>::from_bytes(&bytes);
-  //   deserialized.set_context(context);
-
-  //   // assert_eq!(testpoly, deserialized);
-  //   // Check that result is the same.
-
-  // }
-
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,84 @@
+// use serde::{Serialize, Deserialize};
+use crate::Serializable;
+use std::convert::From;
+use crate::integer_arith::scalar::Scalar;
+use crate::rqpoly::RqPoly;
+use std::convert::TryInto;
+
+pub struct RqPolyWireModel<T> {
+  pub coeffs: Vec<T>,
+  pub is_ntt_form: bool,
+}
+
+pub struct ScalarWireModel{
+  pub rep: u64,
+}
+
+impl From<Scalar> for ScalarWireModel {
+  fn from(item: Scalar) -> Self {
+    ScalarWireModel { rep: item.rep() }
+  }
+}
+
+
+impl Serializable for Scalar{
+  fn to_bytes(&self) -> std::vec::Vec<u8> {
+    let bytes = self.rep().to_be_bytes();
+    let mut vec: Vec<u8> = vec![0; 8];
+    vec.copy_from_slice(&bytes);
+    vec
+  }
+  fn from_bytes(bytes: &std::vec::Vec<u8>) -> Self {
+    let a: u64 = u64::from_be_bytes(bytes.as_slice().try_into().unwrap());
+    Scalar::new(a)
+  }
+}
+
+impl<T> Serializable for RqPoly<T> where T: Serializable{
+  fn to_bytes(&self) -> std::vec::Vec<u8> {
+    let mut vec: Vec<u8> = vec![0,0];
+    // push in the is ntt form.
+    vec.push(self.is_ntt_form as u8);
+    for i in 0..self.coeffs.len(){
+      let mut bytes = self.coeffs[i].to_bytes();
+      // append
+      vec.append(& mut bytes);
+    }
+    vec
+  }
+  fn from_bytes(bytes: &std::vec::Vec<u8>) -> Self {
+    todo!()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  #[test]
+  fn test_scalar_serialization() {
+    let c = Scalar::new(2);
+    let bytes = c.to_bytes();
+    let deserialized_c = Scalar::from_bytes(&bytes);
+    assert_eq!(c, deserialized_c);
+  }
+
+  // fn test_rqpoly_serialization(){
+  //   let context = RqPolyContext::new(4, &Scalar::new_modulus(12289));
+  //   let arc = Arc::new(context);
+  //   let a = from_vec(&vec![1, 0, 0, 0], arc.clone());
+  //   // initialize RqPolys
+  //   // serialize
+  //   // check get back the same poly
+  // }
+}
+
+
+
+// impl<T> Serializable for RqPolyWireModel<T> where T: Serialize{
+
+// }
+
+
+// impl Serializable for ScalarWireModel{
+
+// }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -41,3 +41,11 @@ pub trait AdditiveHomomorphicScheme<CT, PT, SK>: SKEncryption<CT, PT, SK> {
     /// plaintext, while being unlinkable to the input ciphertext.
     fn rerandomize(&self, ct: &mut CT, pk: &CT);
 }
+
+pub trait Serializable{
+
+    fn to_bytes(&self) -> Vec<u8>;
+
+    /// If the input `bytes` slice does not have a length of 32.
+    fn from_bytes(bytes: &Vec<u8>) -> Self;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -43,9 +43,9 @@ pub trait AdditiveHomomorphicScheme<CT, PT, SK>: SKEncryption<CT, PT, SK> {
 }
 
 pub trait Serializable{
-
+    /// Serialize to a vector of bytes.
     fn to_bytes(&self) -> Vec<u8>;
 
-    /// If the input `bytes` slice does not have a length of 32.
+    /// Deserialize from a vector of bytes.
     fn from_bytes(bytes: &Vec<u8>) -> Self;
 }


### PR DESCRIPTION
- Added support to serialize RqPolys and FVCiphertexts into Vec<u8> using the to_bytes function. 
- Added deserialization support through the API  FV::from_bytes(& Vec<u8>). 